### PR TITLE
Skip EmailIdentities with invalid email addr

### DIFF
--- a/ingestors/support/email.py
+++ b/ingestors/support/email.py
@@ -143,6 +143,7 @@ class EmailSupport(TempFileSupport, HTMLSupport, CacheSupport):
                         values.add(value)
             except (TypeError, IndexError, AttributeError, ValueError) as exc:
                 log.warning("Failed to parse [%s]: %s", header, exc)
+
         values = [x.strip() for x in values]
         return values
 
@@ -173,6 +174,9 @@ class EmailSupport(TempFileSupport, HTMLSupport, CacheSupport):
         if isinstance(identities, types.GeneratorType):
             identities = list(identities)
         for identity in ensure_list(identities):
+            # if the EmailIdentity obj has an invalid email attr, skip
+            if not hasattr(identity, "entity"):
+                continue
             if eprop is not None:
                 entity.add(eprop, identity.entity)
             if lprop is not None:


### PR DESCRIPTION
This is a fix that unblocks ingesting any E-mail files that have a name in the To / From / CC / BCC headers, but no e-mail address associated. 

This may happen with back-ups of Inboxes where the identities in those headers are in the user's Contact book. 

The error is caused by cases when `get_header` applied to one of those headers gives us a list of names and no emails like this: `['John Doe', '"John Doe"']`. These values, when fed to `get_identities`, result in a call to create a `EmailIdentity` like so: `EmailIdentity(self.manager, "", "John")` and `EmailIdentity(self.manager, "", "John Doe")` (because `parseaddr` returns the names as the second value, assigned to `email`). The `EmailIdentity` doesn't create a `Person` entity in this case because the e-mail isn't valid. So the fix is to check if the `EmailIdentity` instance has a `entity` attribute. 

This is **a band-aid** and not a proper fix. 

This is a band-aid on top of a big pile of band-aids. 

When it comes to E-mails with no e-mail address in To / From / CC / BCC, what we want is a `Person` FTM entity with a name and nothing else. However, in the `EmailIdentity` logic, a `Person` entity is created from the identity in a header only if it has an email address. In the `EmailIdentity` class itself, this is expressed in a really clumsy way in the `__init__` as follows:

```
def __init__(self, manager, name, email):
...
    # validate email 
    if not self.email:
            return

...
    key = f"email:{self.email}"
        if key is not None:
            fragment = safe_fragment(self.label)
            self.entity = manager.make_entity("Person")
            self.entity.context = {"mutable": False}
            self.entity.make_id(key)
            self.entity.add("name", self.name)
            self.entity.add("email", self.email)
            manager.emit_entity(self.entity, fragment=fragment)
```

In other words, though the ordering of code lines and side-effects, the `Person` entity is only emitted at the end of the `__init__`, but, without a valid e-mail address, the method exits early. 