### PR TITLE
Amended Documentation after One-Shot Docker Setup and Ensuing Issues

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -42,11 +42,12 @@ TESSDATA_PREFIX=/usr/share/tesseract-ocr/5/tessdata
 
 ## Configuration
 
-All configuration is set via environment variables. [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) is used to parse the settings, so a `.env` file can be used as well.
+All configuration is done via environment variables. [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) is used to parse the settings, so a `.env` file can be used as well.
 
 ### Archive
 
 The underlying file archive is implemented via [servicelayer](https://github.com/openaleph/servicelayer) and stores the source files via its SHA1 checksums in a path layout like `ab/cd/ef/abcdef...`.
+NOTE: This configuration is optional and has a working default.
 
 #### Local directory
 
@@ -66,7 +67,8 @@ AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-### FollowTheMoney store
+### FollowTheMoney Store
+
 
 Per default, ingest-file writes Entity data to a local sqlite database:
 
@@ -81,8 +83,12 @@ FTM_STORE_URI=postgresql://user:password@host/database
 !!! warning
     Prior versions of `ingest-file` inferred the FtM store database uri from Aleph environment settings if it was not set explicitly. This behaviour has changed and the `FTM_STORE_URI` has to be set explicitly.
 
+NOTE: This configuration is optional and has a working default, but you
+will probably want to write the output to a location configured by you.
+
 ### Task queue
 
+NOTE: !!This configuration is NOT optional and has to be configured even for one-shot usage!!
 ingest-file uses [openaleph-procrastinate](https://openaleph.org/docs/lib/openaleph-procrastinate/) as a distributed task queue backend which is built on top of [procrastinate](https://procrastinate.readthedocs.io/en/stable/).
 
 Most importantly, the `procrastinate.App` has to be defined:
@@ -100,8 +106,16 @@ OPENALEPH_DB_URI=postgresql://user:password@host/database
 OPENALEPH_PROCRASTINATE_DB_URI=postgresql://user:password@host/database
 ```
 
+Run the setup command to initialize the database:
+
+```bash
+openaleph-procrastinate init-db
+```
+
 ## Redis
 
+
+NOTE: This configuration is optional and has a working default.
 Accepts any valid redis url (including a password). If `REDIS_URL` is not set, an in-memory cache is used which doesn't persist.
 
 ```bash
@@ -110,8 +124,12 @@ REDIS_URL=redis://localhost
 
 ## Debug mode
 
-For local development, testing or a quick one-shot usage, this uses an in-memory store for the task queue (which will not persist)
+NOTE: This configuration is optional and has a working default.
+For local development, testing or a quick one-shot usage, set this value to 1
 
 ```bash
 DEBUG=1
 ```
+
+
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,7 +69,6 @@ ingest the file and output the resulting dataset to the file `./followthemoney.s
 an sqlite database.
 This also produces the directory `./archive`, which will contain the file
 you just ingested.
-If you omit
 
 Note, that this still requires setting up the database beforehand using 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,3 +46,34 @@ DEBUG=1 ingestors ingest -d my_dataset ./path/to/files
 ## CLI Reference
 
 [CLI reference](./reference/cli.md)
+
+## Minimal Out-Of-The-Box  Example
+Note that supplying a sqlite database is not valid in `OPENALEPH_DB_URI`.
+Assuming a postgres database `ingestdb` reachable at `localhost:5432`:
+
+```bash
+docker run -it --rm \
+    -v "$PWD":/data \
+    -e ARCHIVE_PATH=/data/archive \
+    -e FTM_STORE_URI=sqlite:////data/followthemoney.store \
+    -e OPENALEPH_DB_URI=postgresql://user:password@localhost:5432/ingestdb \
+    -e DEBUG=1 \
+    --network=host \
+    ghcr.io/openaleph/ingest-file \
+    ingestors ingest -d my_dataset /data/example.pdf
+```
+
+Which does the following:  
+Given a file in the current directory called `example.pdf`,
+ingest the file and output the resulting dataset to the file `./followthemoney.store`,
+an sqlite database.
+This also produces the directory `./archive`, which will contain the file
+you just ingested.
+If you omit
+
+Note, that this still requires setting up the database beforehand using 
+```bash
+docker run \
+    ...    \
+    openaleph-procrastinate init-db
+```


### PR DESCRIPTION
After trying to follow the documentation I was unable to do a docker one-shot without first configuring a postgres database and within that database the underlying procrastinator database schema, which was an undocumented behavior in setup and usage.

So I amended that to the documentation and gave a minimal example to run with docker. 
This could also be a bug, but since I am not sure, the documentation now reflects the current behavior.

In the same way I also documented which configurations were optional, and which had to be there for the program not to error on startup and produce a minimal entity.

If you feel that this is wrong or incomplete, feel free to close or change this PR.