### PR TITLE
Add verbose error for zero byte files

### DIFF
--- a/ingestors/exc.py
+++ b/ingestors/exc.py
@@ -1,4 +1,5 @@
 ENCRYPTED_MSG = "The document might be protected with a password. Try removing the password protection and re-uploading the documents."
+EMPTY_MSG = "The source file is empty (0 bytes) and has no content to extract."
 
 
 class ProcessingException(Exception):

--- a/ingestors/ignore.py
+++ b/ingestors/ignore.py
@@ -54,9 +54,6 @@ class IgnoreIngestor(Ingestor):
 
     @classmethod
     def match(cls, file_path, entity):
-        for file_size in entity.get("fileSize"):
-            if int(file_size) == 0:
-                return cls.SCORE * 100
         for file_name in entity.get("fileName"):
             if file_name in cls.NAMES:
                 return cls.SCORE

--- a/ingestors/manager.py
+++ b/ingestors/manager.py
@@ -27,7 +27,7 @@ from servicelayer.extensions import get_extensions
 
 from ingestors import __version__
 from ingestors.directory import DirectoryIngestor
-from ingestors.exc import ENCRYPTED_MSG, ProcessingException
+from ingestors.exc import EMPTY_MSG, ENCRYPTED_MSG, ProcessingException
 from ingestors.ingestor import Ingestor
 from ingestors.misc.tika import TikaIngestor
 from ingestors.settings import Settings
@@ -237,6 +237,13 @@ class Manager:
         ingestor_name = None
 
         try:
+            # Handle zero-byte files before auction. Resolve mimeType
+            # then raise so the emitted entity keeps its file properties.
+            if file_size == 0:
+                if not entity.has("mimeType"):
+                    entity.add("mimeType", self.MAGIC.from_file(file_path.as_posix()))
+                raise ProcessingException(EMPTY_MSG)
+
             ingestor_class = self.auction(file_path, entity)
             ingestor_name = ingestor_class.__name__
             log.info(f"Ingestor [{repr(entity)}]: {ingestor_name}")

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -2,7 +2,8 @@
 
 from normality.cleaning import collapse_spaces
 
-from ingestors.exc import ENCRYPTED_MSG
+from ingestors.exc import EMPTY_MSG, ENCRYPTED_MSG
+from ingestors.manager import Manager
 from tests.support import TestCase
 
 
@@ -15,7 +16,13 @@ class PDFIngestorTest(TestCase):
     def test_match_empty(self):
         fixture_path, entity = self.fixture("empty.pdf")
         self.manager.ingest(fixture_path, entity)
-        self.assertNotEqual(entity.first("mimeType"), "application/pdf")
+        self.assertEqual(entity.first("processingStatus"), Manager.STATUS_FAILURE)
+        self.assertEqual(entity.first("processingError"), EMPTY_MSG)
+        # the emitted entity keeps its file properties
+        self.assertEqual(entity.first("fileName"), "empty.pdf")
+        self.assertEqual(int(entity.first("fileSize")), 0)
+        self.assertIsNotNone(entity.first("contentHash"))
+        self.assertIsNotNone(entity.first("mimeType"))
 
     def test_ingest_binary_mode(self):
         fixture_path, entity = self.fixture("readme.pdf")


### PR DESCRIPTION
addresses #40 - skips the auction for files without content while preserving properties. Introduces specific error for empty files.